### PR TITLE
Simplify script entry points

### DIFF
--- a/2025/2025.py
+++ b/2025/2025.py
@@ -14,7 +14,7 @@ def is_it(number):
             continue
     return False
 
-def main():
+if __name__ == '__main__':
     lst = []
     i = 1
     while True:
@@ -24,8 +24,5 @@ def main():
         if is_it(square):
             lst.append(square)
         i += 1
-    return sum(lst)
-
-if __name__ == '__main__':
-    print(main())
+    print(sum(lst))
 #20 dk da bitti

--- a/Amicable_Numbers/Amicable_Numbers.py
+++ b/Amicable_Numbers/Amicable_Numbers.py
@@ -26,11 +26,8 @@ def amicable_sums(value_lst):
         result += i
     return result
 
-def main():
+if __name__ == "__main__":
     value = int(input("value = "))
     a = amicable(value)
     b = amicable_sums(a)
     print(b)
-
-if __name__ == "__main__":
-    main()

--- a/Champernowne's_Constant/Champernowne's_Constant.py
+++ b/Champernowne's_Constant/Champernowne's_Constant.py
@@ -13,7 +13,5 @@ def find_pos():
 
     return product
 
-def main():
-    print(find_pos())
 if __name__ == "__main__":
-    main()
+    print(find_pos())

--- a/Circular_Primes/Circular_Primes.py
+++ b/Circular_Primes/Circular_Primes.py
@@ -13,11 +13,9 @@ def circular(value):
             return False
     return True
 
-def main():
+if __name__ == "__main__":
     counter = 0
     for i in range(2,1000000):
         if is_prime(i) and circular(i):
             counter += 1
     print(counter)
-if __name__ == "__main__":
-    main()

--- a/Consecutive_Prime_Sum/Consecutive_Prime_Sum.py
+++ b/Consecutive_Prime_Sum/Consecutive_Prime_Sum.py
@@ -37,7 +37,5 @@ def C_Prime_Sum():
 
     return result, max_length
 
-def main():
-    print(C_Prime_Sum())
 if __name__ == '__main__':
-    main()
+    print(C_Prime_Sum())

--- a/Digit_Cancelling_Fractions/Digit_Cancelling_Fractions.py
+++ b/Digit_Cancelling_Fractions/Digit_Cancelling_Fractions.py
@@ -30,15 +30,11 @@ def fraction():
 
     return lst
 
-def main():
+if __name__ == "__main__":
     fractions = fraction()
     product = 1
     for frac in fractions:
         product *= frac
 
-
     result = product.limit_denominator()
     print(result)
-
-if __name__ == "__main__":
-    main()

--- a/Digit_Factorials/Digit_Factorials.py
+++ b/Digit_Factorials/Digit_Factorials.py
@@ -18,8 +18,5 @@ def sums(value):
         result += factorial(int(i))
     return result
 
-def main():
-    print(is_it())
-
 if __name__ == "__main__":
-    main()
+    print(is_it())

--- a/Digit_Fifth_Powers/Digit_Fifth_Powers.py
+++ b/Digit_Fifth_Powers/Digit_Fifth_Powers.py
@@ -16,7 +16,5 @@ def is_it(value):
         result += int(i)**5
     return result
 
-def main():
-    print(fight())
 if __name__ == "__main__":
-    main()
+    print(fight())

--- a/Distinct_Powers/Distinct_Powers.py
+++ b/Distinct_Powers/Distinct_Powers.py
@@ -9,7 +9,5 @@ def power_number():
                 lst.append(value)
 
     return len(lst)
-def main():
-    print(power_number())
 if __name__ == "__main__":
-    main()
+    print(power_number())

--- a/Distinct_Primes_Factors/Distinct_Primes_Factors.py
+++ b/Distinct_Primes_Factors/Distinct_Primes_Factors.py
@@ -13,7 +13,7 @@ def Find_primes(number):
     return lst
 
 
-def main():
+if __name__ == '__main__':
 
     order = 0
     i = 2
@@ -26,7 +26,3 @@ def main():
         else:
             order = 0
         i += 1
-
-
-if __name__ == '__main__':
-    main()

--- a/Double-base_Palindromes/Double-base_Palindromes.py
+++ b/Double-base_Palindromes/Double-base_Palindromes.py
@@ -10,9 +10,7 @@ def sum_palindromes(n):
             total_sum += i
     return total_sum
 
-def main():
+if __name__ == "__main__":
     n = 1000000
     result = sum_palindromes(n)
     print(result)
-if __name__ == "__main__":
-    main()

--- a/Factorial_Digit_Sum/Factorial_Digit_Sum.py
+++ b/Factorial_Digit_Sum/Factorial_Digit_Sum.py
@@ -10,10 +10,8 @@ def sum(value):
         result += int(i)
     return result
 
-def main():
+if __name__ =="__main__":
     value = int(input("value ="))
     a = factoriel(value)
     b = sum(a)
     print(b)
-if __name__ =="__main__":
-    main()

--- a/Goldbach_Other_Conjecture/Goldbach_Other_Conjecture.py
+++ b/Goldbach_Other_Conjecture/Goldbach_Other_Conjecture.py
@@ -19,12 +19,10 @@ def is_written(n):
                     return True
     return False
 
-def main():
-    n = 9  
+if __name__ == "__main__":
+    n = 9
     while True:
         if not is_prime(n) and not is_written(n):
-            return n
-        n += 2  
-
-if __name__ == "__main__":
-    print(main())
+            print(n)
+            break
+        n += 2

--- a/Highly_Divisible_Triangular_Number/Highly_Divisible_Triangular_Number.py
+++ b/Highly_Divisible_Triangular_Number/Highly_Divisible_Triangular_Number.py
@@ -18,8 +18,5 @@ def derive(number):
         counter -= 1
     return counter
 
-def main():
-    print(triangle_number())
-
 if __name__ == "__main__":
-    main()
+    print(triangle_number())

--- a/Integer_Right_Triangles/Integer_Right_Triangles.py
+++ b/Integer_Right_Triangles/Integer_Right_Triangles.py
@@ -13,8 +13,6 @@ def count_p(max_p):
     max_p = max(dic, key=dic.get)
     return max_p, dic[max_p]
 
-def main():
+if __name__ == "__main__":
     print(count_p(1000))
     #cozum sayisinin en fazla oldugu p degeri: argv [0], cozum sayisi: argv [1]}
-if __name__ == "__main__":
-    main()

--- a/Largest_Prime_Factor/c3.py
+++ b/Largest_Prime_Factor/c3.py
@@ -1,29 +1,25 @@
 import sys
 
-def main():
+if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Kullanım: python script.py <sayı>")
-        return
+    else:
+        number = int(sys.argv[1])
+        largest_number = 0
+        is_prime = False
 
-    number = int(sys.argv[1])
-    largest_number = 0
-    is_prime = False
+        i = 2
+        while i < number // 2:
+            if number % i == 0:
+                j = 2
+                while j < i:
+                    if i % j == 0:
+                        is_prime = False
+                        break
+                    is_prime = True
+                    j += 1
+                if is_prime:
+                    largest_number = i
+            i += 1
 
-    i = 2
-    while i < number // 2:
-        if number % i == 0:
-            j = 2
-            while j < i:
-                if i % j == 0:
-                    is_prime = False
-                    break
-                is_prime = True
-                j += 1
-            if is_prime:
-                largest_number = i
-        i += 1
-
-    print(largest_number)
-
-if __name__ == "__main__":
-    main()
+        print(largest_number)

--- a/Longest_Collatz_Sequence/Longest_Collatz_Sequence.py
+++ b/Longest_Collatz_Sequence/Longest_Collatz_Sequence.py
@@ -22,7 +22,5 @@ def chain():
 
 
 
-def main():
-    print(chain())
 if __name__ == "__main__":
-    main()
+    print(chain())

--- a/Multiples_of_3_or_5/3_5.py
+++ b/Multiples_of_3_or_5/3_5.py
@@ -1,4 +1,4 @@
-def main():
+if __name__ == "__main__":
     bellow = int(input(""))
     sum = 0
 
@@ -7,6 +7,3 @@ def main():
             sum += i
 
     print(sum)
-
-if __name__ == "__main__":
-    main()

--- a/Non-Abundant_Sums/Non-Abundant_Sums.py
+++ b/Non-Abundant_Sums/Non-Abundant_Sums.py
@@ -28,8 +28,5 @@ def abound():
     return result
 
 
-def main():
-    print(abound())
-
 if __name__ == "__main__":
-    main()
+    print(abound())

--- a/Number_Spiral_Diagonals/Number_Spiral_Diagonals.py
+++ b/Number_Spiral_Diagonals/Number_Spiral_Diagonals.py
@@ -8,8 +8,5 @@ def spiral():
         return_value += an + bn + cn + dn
     return return_value
 
-def main():
-    print(spiral())
-
 if __name__ == "__main__":
-    main()
+    print(spiral())

--- a/Pandigital_Multiples/Pandigital_Multiples.py
+++ b/Pandigital_Multiples/Pandigital_Multiples.py
@@ -2,6 +2,7 @@ def is_pandigital(num):
     num_str = str(num)
     return len(num_str) == 9 and set(num_str) == set("123456789")
 
+
 def find_largest_pandigital():
     largest_pandigital = 0
 
@@ -11,34 +12,33 @@ def find_largest_pandigital():
         while len(concatenated_product) < 9:
             concatenated_product += str(i * n)
             n += 1
-
- def cozum_sayisini_hesapla(max_p):
-     cozumler = {}  # Çevre değerine göre çözüm sayısını tutacak sözlük
-
-     for a in range(1, max_p // 2):
-         for b in range(a, max_p // 2):
-             c = (a ** 2 + b ** 2) ** 0.5
-             if c == int(c):  # c tam sayı mı kontrol et
-                 p = a + b + int(c)
-                 if p <= max_p:
-                     if p not in cozumler:
-                         cozumler[p] = 1
-                     else:
-                         cozumler[p] += 1
-
-     en_fazla_cozum_p = max(cozumler, key=cozumler.get)
-     return en_fazla_cozum_p, cozumler[en_fazla_cozum_p]
-
- max_p = 1000
- sonuc = cozum_sayisini_hesapla(max_p)
- print(f"Çözüm sayısının en fazla olduğu p değeri: {sonuc[0]}, Çözüm sayısı: {sonuc[1]}")
-       if len(concatenated_product) == 9 and is_pandigital(concatenated_product):
+        if len(concatenated_product) == 9 and is_pandigital(concatenated_product):
             largest_pandigital = max(largest_pandigital, int(concatenated_product))
 
     return largest_pandigital
 
-def main():
-    print(find_largest_pandigital())
+
+def cozum_sayisini_hesapla(max_p):
+    cozumler = {}
+
+    for a in range(1, max_p // 2):
+        for b in range(a, max_p // 2):
+            c = (a ** 2 + b ** 2) ** 0.5
+            if c == int(c):
+                p = a + b + int(c)
+                if p <= max_p:
+                    if p not in cozumler:
+                        cozumler[p] = 1
+                    else:
+                        cozumler[p] += 1
+
+    en_fazla_cozum_p = max(cozumler, key=cozumler.get)
+    return en_fazla_cozum_p, cozumler[en_fazla_cozum_p]
+
 
 if __name__ == "__main__":
-    main()
+    print(find_largest_pandigital())
+
+    max_p = 1000
+    sonuc = cozum_sayisini_hesapla(max_p)
+    print(f"Çözüm sayısının en fazla olduğu p değeri: {sonuc[0]}, Çözüm sayısı: {sonuc[1]}")

--- a/Pandigital_Products/Pandigital_Products.py
+++ b/Pandigital_Products/Pandigital_Products.py
@@ -15,7 +15,5 @@ def is_pandigital(i, j, value):
         return True
     return False
 
-def main():
-    print(product())
 if __name__ == "__main__":
-    main()
+    print(product())

--- a/Pandijital_Prime/Pandijital_Prime.py
+++ b/Pandijital_Prime/Pandijital_Prime.py
@@ -18,7 +18,7 @@ def permutasyon(rakamlar):
 
     return permutasyonlar
 
-def main():
+if __name__ == "__main__":
     max_result = 0
     digit = "7654321"
     permutations = permutasyon(digit)
@@ -28,6 +28,4 @@ def main():
         if is_prime(num):
             max_result = max(max_result, num)
 
-    return max_result
-
-print(main())
+    print(max_result)

--- a/Pentagon_Numbers/Pentagon_Numbers.py
+++ b/Pentagon_Numbers/Pentagon_Numbers.py
@@ -6,7 +6,7 @@ def is_pentagonal(n):
         return True
     return False
 
-def main():
+if __name__ == "__main__":
     flag = True
     i = 1
     while flag:
@@ -17,7 +17,4 @@ def main():
                 print(a - b)
                 flag = False
                 break
-        i += 1  
-
-if __name__ == "__main__":
-    main()
+        i += 1

--- a/Permuted_Multiples/Permuted_Multiples.py
+++ b/Permuted_Multiples/Permuted_Multiples.py
@@ -1,14 +1,12 @@
-def main():
-    find = False
-    number = 2
-    while not find:
-        nbr1 = sorted(str(number))
-        if nbr1 == sorted(str(2*number)):
-            if nbr1 == sorted(str(3*number)):
-                if nbr1 == sorted(str(4*number)):
-                    if nbr1 == sorted(str(5*number)):
-                        if nbr1 == sorted(str(6*number)):
-                            return number
-        number += 1
 if __name__ == '__main__':
-    print(main())
+    number = 2
+    while True:
+        nbr1 = sorted(str(number))
+        if nbr1 == sorted(str(2 * number)):
+            if nbr1 == sorted(str(3 * number)):
+                if nbr1 == sorted(str(4 * number)):
+                    if nbr1 == sorted(str(5 * number)):
+                        if nbr1 == sorted(str(6 * number)):
+                            print(number)
+                            break
+        number += 1

--- a/Permuted_Multiples/better_code.py
+++ b/Permuted_Multiples/better_code.py
@@ -7,12 +7,10 @@ def check_multiple(number):
             return False
     return True
 
-def main():
+if __name__ == '__main__':
     number = 1
     while True:
         if check_multiple(number):
-            return number
+            print(number)
+            break
         number += 1
-
-if __name__ == '__main__':
-    print(main())

--- a/Power_digit_sum/Power_Digit_Sum.py
+++ b/Power_digit_sum/Power_Digit_Sum.py
@@ -8,9 +8,7 @@ def sum(value):
         result += int(i)
     return result
 
-def main():
+if __name__ == "__main__":
     value = int(input("value:"))
     sum_result = digit(value)
     print(sum(sum_result))
-if __name__ == "__main__":
-    main()

--- a/Powerful_Digit_Counts/Powerful_Digit_Counts.py
+++ b/Powerful_Digit_Counts/Powerful_Digit_Counts.py
@@ -18,7 +18,7 @@ def digit_power(number):
             return result
         i+=1
 
-def main():
+def count_powerful_digits():
     p = 1
     return_value = 0
     while True:
@@ -28,4 +28,4 @@ def main():
         if n == 0:
             return return_value
 if __name__ == '__main__':
-    run_with_timer(main)
+    run_with_timer(count_powerful_digits)

--- a/Prime_Pair_Sets/Prime_Pair_Sets.py
+++ b/Prime_Pair_Sets/Prime_Pair_Sets.py
@@ -43,7 +43,7 @@ def find_prime_sets(primes, size):
             return result
     return None
 
-def main():
+if __name__ == '__main__':
     numbers = list_of_primes()
     result = find_prime_sets(numbers, 5)
     if result:
@@ -51,11 +51,3 @@ def main():
         print("Toplam:", sum(result))
     else:
         print("Uygun küme bulunamadı.")
-
-
-
-
-
-
-if __name__ == '__main__':
-    main()

--- a/Prime_Permutations/Prime_Permutations.py
+++ b/Prime_Permutations/Prime_Permutations.py
@@ -3,11 +3,13 @@ def is_prime(number):
         if number % i == 0:
             return False
     return True
-def main():
+if __name__ == '__main__':
     primes = []
     for i in range(1000, 10000):
         if is_prime(i):
             primes.append(i)
+
+    result = None
     for i in range(len(primes)):
         for j in range(i + 1, len(primes)):
             a = primes[i]
@@ -19,8 +21,10 @@ def main():
                 if sorted(str(a)) == sorted(str(b)) == sorted(str(c)):
                     triplet = (a, b, c)
                     if triplet != (1487, 4817, 8147):
-                        return f"{a}{b}{c}"
+                        result = f"{a}{b}{c}"
+                        break
+        if result:
+            break
 
-
-if __name__ == '__main__':
-    print(main())
+    if result:
+        print(result)

--- a/Quadratic_Primes/Quadratic_Primes.py
+++ b/Quadratic_Primes/Quadratic_Primes.py
@@ -26,8 +26,5 @@ def is_prime(value):
             return False
     return True
 
-def main():
-    print(quadratic())
-
 if __name__ == "__main__":
-    main()
+    print(quadratic())

--- a/Reciprocal_Cycles/Reciprocal_Cycles.py
+++ b/Reciprocal_Cycles/Reciprocal_Cycles.py
@@ -30,7 +30,7 @@ def fractionToDecimal(numerator, denominator):
     return "".join(result)
 
 
-def main():
+if __name__ == "__main__":
     result = 0
     return_value = 0
     a = 0
@@ -43,4 +43,3 @@ def main():
             a = i
 
     print(a)
-main()

--- a/Self_Powers/Self_Powers.py
+++ b/Self_Powers/Self_Powers.py
@@ -3,13 +3,10 @@ def self_power(number):
 
 
 
-def main():
+if __name__ == '__main__':
     print_value = 0
     for i in range(1,1001):
         print_value +=  self_power(i)
 
     str_pv = str(print_value)[-10:]
     print(str_pv)
-
-if __name__ == '__main__':
-    main()

--- a/Special_Pythagorean_Triplet/Special_Pythagorean_Triplet.py
+++ b/Special_Pythagorean_Triplet/Special_Pythagorean_Triplet.py
@@ -4,8 +4,6 @@ def triangle(value):
             c = value - a - b
             if a*a + b*b == c*c:
                 return a*b*c
-def main():
+if __name__ == "__main__":
     value = int(input("value:"))
     print(triangle(value))
-if __name__ == "__main__":
-    main()

--- a/Summation_of_Primes/Summation_of_Primes.py
+++ b/Summation_of_Primes/Summation_of_Primes.py
@@ -14,8 +14,6 @@ def sum_of_primes(value):
     return total + 2
 
 
-def main():
-   value = int(input("value:"))
-   print(sum_of_primes(value))
 if __name__ == "__main__":
-        main()
+    value = int(input("value:"))
+    print(sum_of_primes(value))

--- a/Triangular,_Pentagonal,_and_Hexagonal/Triangular,_Pentagonal,_and_Hexagonal.py
+++ b/Triangular,_Pentagonal,_and_Hexagonal/Triangular,_Pentagonal,_and_Hexagonal.py
@@ -16,15 +16,12 @@ def is_pentagonal(n):
 def is_hexagonal(n):
     return (1 + (8 * n + 1)**0.5) % 4 == 0
 
-def main():
-    value1 = 286  
+if __name__ == "__main__":
+    value1 = 286
     while True:
         triangle_number = Triangle(value1)
         if is_pentagonal(triangle_number) and is_hexagonal(triangle_number):
             print(triangle_number)
             break
-        
-        value1 += 1
 
-if __name__ == "__main__":
-    main()
+        value1 += 1

--- a/Truncatable_Primes/Truncatable_Primes.py
+++ b/Truncatable_Primes/Truncatable_Primes.py
@@ -28,8 +28,5 @@ def sums_of_prime():
         n += 1
 
     return total_sum
-def main():
-    print(sums_of_prime())
-
 if __name__ == "__main__":
-    main()
+    print(sums_of_prime())


### PR DESCRIPTION
## Summary
- inline the top-level execution logic in each Project Euler solution instead of routing through trivial `main()` wrappers
- adjust scripts that previously returned values from `main()` so they now print results directly when executed
- clean up the Pandigital Multiples module so both helper functions and execution blocks are properly defined outside each other

## Testing
- python -m compileall .  # fails because Prime_Pair_Sets/p.py already contains a SyntaxError
- python -m compileall Pandigital_Multiples/Pandigital_Multiples.py


------
https://chatgpt.com/codex/tasks/task_e_68caf9552590832495a7b9877de3eef4